### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,10 @@
 
 A responsive front-end web app for Openframe.
 
-> More info coming...
+### Local Development Setup
+
+Install the dependencies: `npm i`
+
+Create a `.env` file using `.env-sample` as an example. Make sure to set the `API_HOST` variable to point to the desired API host.
+
+Run the web app via the webpack dev server: `npm start`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A responsive front-end web app for Openframe.
 
 Install the dependencies: `npm i`
 
-Create a `.env` file using `.env-sample` as an example. Make sure to set the `API_HOST` variable to point to the desired API host.
+Create a `.env` file using `.env-sample` as an example. Make sure to set the `API_HOST` variable to point to the desired API host. For example:
+- for a local Openframe API server: `API_HOST=http://0.0.0.0:8888`
+- for the official Openframe production API server: `API_HOST=https://api.openframe.io/v0/`
 
 Run the web app via the webpack dev server: `npm start`


### PR DESCRIPTION
@jvolker I moved the `API_HOST` config to an env var and update the dev build to pull in vars from a .env file, which is why you were seeing the requests going to localhost again. Added brief docs to the README here.